### PR TITLE
Update cron schedule to run every 12 hours

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,10 +6,10 @@
 	"observability": {
 		"enabled": true
 	},
-	// Run hourly
+	// Run every 12 hours
 	"triggers": {
 		"crons": [
-			"0 * * * *"
+			"0 */12 * * *"
 		]
 	},
 	// Local dev will auto-stub this; for prod, run:


### PR DESCRIPTION
The cron schedule in wrangler.jsonc was updated from running every hour to every 12 hours.